### PR TITLE
 support telemetry on temperature, input voltage, current, and load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package dynamixel_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2.0.0 (2024-02-08)
+------------------
+* **BREAKING**: Add telemetry fields to DynamixelState message
+  
+  - Added present_temperature (int16[])
+  - Added present_input_voltage (int16[]) 
+  - Added present_current (int16[])
+  - Added present_load (int16[])
+  
+  Downstream packages must:
+  1. Rebuild against new message definition
+  2. Update code if parsing DynamixelState messages
+  
 
 1.0.1 (2025-03-11)
 ------------------

--- a/msg/DynamixelState.msg
+++ b/msg/DynamixelState.msg
@@ -4,8 +4,8 @@ int32 comm_state
 int32[] id
 bool[] torque_state
 int32[] dxl_hw_state
-int16[] temperature
-int16[] voltage
+int16[] present_temperature
+int16[] present_input_voltage
 int16[] present_current
 int16[] present_load
 

--- a/msg/DynamixelState.msg
+++ b/msg/DynamixelState.msg
@@ -1,5 +1,8 @@
 std_msgs/Header header
 
+# all arrays in tandem, elements at ith position correspond to servo noted in id[]
+# see corresponding servo manuals for return values and ranges
+
 int32 comm_state
 int32[] id
 bool[] torque_state

--- a/msg/DynamixelState.msg
+++ b/msg/DynamixelState.msg
@@ -4,6 +4,10 @@ int32 comm_state
 int32[] id
 bool[] torque_state
 int32[] dxl_hw_state
+int16[] temperature
+int16[] voltage
+int16[] present_current
+int16[] present_load
 
 int32 COMM_STATE_OK = 0
 int32 COMM_STATE_CANNOT_FIND_CONTROL_ITEM = -1

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <package format="3">
   <name>dynamixel_interfaces</name>
-  <version>1.0.1</version>
+  <version>2.0.0</version>
   <description>
     dynamixel_interfaces contains base messages and service useful for controlling Dynamixel.
   </description>


### PR DESCRIPTION
This PR adds the necessary structure to pull telemetry information for Present Input Voltage, Temperature, Current, and/or load. This is in support of Issue #8  and is a companion PR to be paired up with (and merged before): https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface/pull/106 . See that PR for more details.